### PR TITLE
Add gen from ddl subcommand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ jobs:
             git diff --quiet tplbin/
 
       - run:
+          name: regenerate testdata-from-ddl and check diff
+          command: |
+            make testdata-from-ddl YOBIN=./yo
+            git diff --quiet test/
+
+      - run:
           name: regenerate template files and check diff
           command: |
             make recreate-templates YOBIN=./yo

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:0276f0bc42bdc5eadf005c8f0c843f859eeb8fef5e4e864fe96fa78447404841"
+  name = "github.com/MakeNowJust/memefish"
+  packages = ["pkg/parser"]
+  pruneopts = "UT"
+  revision = "8cb375afb10dbf705bc053188dd960e692397d66"
+
+[[projects]]
+  branch = "master"
   digest = "1:738fb270ddc762898f14fec8e4c6ba51720cdf00f0d1fb44d29a550282f24c78"
   name = "github.com/gedex/inflector"
   packages = ["."]
@@ -443,6 +451,7 @@
     "cloud.google.com/go/spanner",
     "cloud.google.com/go/spanner/admin/database/apiv1",
     "cloud.google.com/go/spanner/spannertest",
+    "github.com/MakeNowJust/memefish/pkg/parser",
     "github.com/gedex/inflector",
     "github.com/google/go-cmp/cmp",
     "github.com/jessevdk/go-assets",
@@ -450,6 +459,7 @@
     "github.com/spf13/cobra",
     "google.golang.org/api/iterator",
     "google.golang.org/api/option",
+    "google.golang.org/genproto/googleapis/spanner/admin/database/v1",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/status",

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,21 @@ testdata/customtypes:
 	rm -rf test/testmodels/customtypes && mkdir -p test/testmodels/customtypes
 	$(YOBIN) $(SPANNER_PROJECT_NAME) $(SPANNER_INSTANCE_NAME) $(SPANNER_DATABASE_NAME) --custom-types-file test/testdata/custom_column_types.yml --out test/testmodels/customtypes/
 
+testdata-from-ddl:
+	$(MAKE) -j4 testdata-from-ddl/default testdata-from-ddl/customtypes testdata-from-ddl/single
+
+testdata-from-ddl/default:
+	rm -rf test/testmodels/default && mkdir -p test/testmodels/default
+	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --package models --out test/testmodels/default/
+
+testdata-from-ddl/single:
+	rm -rf test/testmodels/single && mkdir -p test/testmodels/single
+	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --out test/testmodels/single/single_file.go --single-file
+
+testdata-from-ddl/customtypes:
+	rm -rf test/testmodels/customtypes && mkdir -p test/testmodels/customtypes
+	$(YOBIN) generate ./test/testdata/schema.sql --from-ddl --custom-types-file test/testdata/custom_column_types.yml --out test/testmodels/customtypes/
+
 recreate-templates::
 	rm -rf templates && mkdir templates
 	$(YOBIN) create-template --template-path templates

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.mercari.io/yo/generator"
+	"go.mercari.io/yo/internal"
+	"go.mercari.io/yo/loaders"
+)
+
+var (
+	generateOpts = internal.ArgType{}
+	generateCmd  = &cobra.Command{
+		Use:   "generate",
+		Short: "yo generate generates Go code from ddl file.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if l := len(args); l != 1 && l != 3 {
+				return fmt.Errorf("must specify 1 or 3 arguments")
+			}
+			return nil
+		},
+		Example: `  # Generate models from ddl under models directory
+  yo generate schema.sql --from-ddl -o models
+
+  # Generate models from ddl under models directory with custom types
+  yo generate schema.sql --from-ddl -o models --custom-types-file custom_column_types.yml
+
+  # Generate models under models directory
+  yo generate $PROJECT_NAME $INSTANCE_NAME $DATABASE_NAME -o models
+
+  # Generate models under models directory with custom types
+  yo generate $PROJECT_NAME $INSTANCE_NAME $DATABASE_NAME -o models --custom-types-file custom_column_types.yml
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := processArgs(&generateOpts, args); err != nil {
+				return err
+			}
+
+			var loader *internal.TypeLoader
+			if generateOpts.FromDDL {
+				spannerLoader, err := loaders.NewSpannerLoaderFromDDL(args[0])
+				if err != nil {
+					return fmt.Errorf("error: %v", err)
+				}
+				loader = internal.NewTypeLoader(spannerLoader)
+			} else {
+				spannerClient, err := connectSpanner(&rootOpts)
+				if err != nil {
+					return fmt.Errorf("error: %v", err)
+				}
+				spannerLoader := loaders.NewSpannerLoader(spannerClient)
+				loader = internal.NewTypeLoader(spannerLoader)
+			}
+
+			// load custom type definitions
+			if generateOpts.CustomTypesFile != "" {
+				if err := loader.LoadCustomTypes(generateOpts.CustomTypesFile); err != nil {
+					return fmt.Errorf("load custom types file failed: %v", err)
+				}
+			}
+
+			// load defs into type map
+			tableMap, ixMap, err := loader.LoadSchema(&generateOpts)
+			if err != nil {
+				return fmt.Errorf("error: %v", err)
+			}
+
+			g := generator.NewGenerator(loader, generator.GeneratorOption{
+				PackageName:       generateOpts.Package,
+				Tags:              generateOpts.Tags,
+				TemplatePath:      generateOpts.TemplatePath,
+				CustomTypePackage: generateOpts.CustomTypePackage,
+				FilenameSuffix:    generateOpts.Suffix,
+				SingleFile:        generateOpts.SingleFile,
+				Filename:          generateOpts.Filename,
+				Path:              generateOpts.Path,
+			})
+			if err := g.Generate(tableMap, ixMap); err != nil {
+				return fmt.Errorf("error: %v", err)
+			}
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	generateCmd.Flags().BoolVar(&generateOpts.FromDDL, "from-ddl", false, "toggle using ddl file")
+	setRootOpts(generateCmd, &generateOpts)
+	rootCmd.AddCommand(generateCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,28 +88,36 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&rootOpts.CustomTypesFile, "custom-types-file", "", "custom table field type definition file")
-	rootCmd.Flags().StringVarP(&rootOpts.Out, "out", "o", "", "output path or file name")
-	rootCmd.Flags().StringVar(&rootOpts.Suffix, "suffix", defaultSuffix, "output file suffix")
-	rootCmd.Flags().BoolVar(&rootOpts.SingleFile, "single-file", false, "toggle single file output")
-	rootCmd.Flags().StringVarP(&rootOpts.Package, "package", "p", "", "package name used in generated Go code")
-	rootCmd.Flags().StringVar(&rootOpts.CustomTypePackage, "custom-type-package", "", "Go package name to use for custom or unknown types")
-	rootCmd.Flags().StringArrayVar(&rootOpts.IgnoreFields, "ignore-fields", nil, "fields to exclude from the generated Go code types")
-	rootCmd.Flags().StringArrayVar(&rootOpts.IgnoreTables, "ignore-tables", nil, "tables to exclude from the generated Go code types")
-	rootCmd.Flags().StringVar(&rootOpts.TemplatePath, "template-path", "", "user supplied template path")
-	rootCmd.Flags().StringVar(&rootOpts.Tags, "tags", "", "build tags to add to package header")
+	setRootOpts(rootCmd, &rootOpts)
+}
 
-	helpFn := rootCmd.HelpFunc()
-	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+func setRootOpts(cmd *cobra.Command, opts *internal.ArgType) {
+	cmd.Flags().StringVar(&opts.CustomTypesFile, "custom-types-file", "", "custom table field type definition file")
+	cmd.Flags().StringVarP(&opts.Out, "out", "o", "", "output path or file name")
+	cmd.Flags().StringVar(&opts.Suffix, "suffix", defaultSuffix, "output file suffix")
+	cmd.Flags().BoolVar(&opts.SingleFile, "single-file", false, "toggle single file output")
+	cmd.Flags().StringVarP(&opts.Package, "package", "p", "", "package name used in generated Go code")
+	cmd.Flags().StringVar(&opts.CustomTypePackage, "custom-type-package", "", "Go package name to use for custom or unknown types")
+	cmd.Flags().StringArrayVar(&opts.IgnoreFields, "ignore-fields", nil, "fields to exclude from the generated Go code types")
+	cmd.Flags().StringArrayVar(&opts.IgnoreTables, "ignore-tables", nil, "tables to exclude from the generated Go code types")
+	cmd.Flags().StringVar(&opts.TemplatePath, "template-path", "", "user supplied template path")
+	cmd.Flags().StringVar(&opts.Tags, "tags", "", "build tags to add to package header")
+
+	helpFn := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		helpFn(cmd, args)
 		os.Exit(1)
 	})
 }
 
 func processArgs(args *internal.ArgType, argv []string) error {
-	rootOpts.Project = argv[0]
-	rootOpts.Instance = argv[1]
-	rootOpts.Database = argv[2]
+	if len(argv) == 3 {
+		rootOpts.Project = argv[0]
+		rootOpts.Instance = argv[1]
+		rootOpts.Database = argv[2]
+	} else {
+		rootOpts.DDLFilepath = argv[0]
+	}
 
 	path := ""
 	filename := ""

--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -49,4 +49,10 @@ type ArgType struct {
 
 	Path     string
 	Filename string
+
+	// DDLFilepath is the filepath of the ddl file.
+	DDLFilepath string
+
+	// FromDDL indicates generating from ddl flie or not.
+	FromDDL bool
 }

--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -1,0 +1,140 @@
+package loaders
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/MakeNowJust/memefish/pkg/parser"
+	"go.mercari.io/yo/models"
+)
+
+func NewSpannerLoaderFromDDL(fpath string) (*SpannerLoaderFromDDL, error) {
+	b, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	tables := make(map[string]table)
+	stmts := strings.Split(string(b), ";")
+	for _, stmt := range stmts {
+		stmt := strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		ddl, err := (&parser.Parser{
+			Lexer: &parser.Lexer{
+				File: &parser.File{FilePath: fpath, Buffer: stmt},
+			},
+		}).ParseDDL()
+		if err != nil {
+			return nil, err
+		}
+
+		switch val := ddl.(type) {
+		case *parser.CreateTable:
+			v := tables[val.Name.Name]
+			v.createTable = val
+			tables[val.Name.Name] = v
+		case *parser.CreateIndex:
+			v := tables[val.TableName.Name]
+			v.createIndexes = append(v.createIndexes, val)
+			tables[val.TableName.Name] = v
+		default:
+			return nil, fmt.Errorf("stmt should be CreateTable or CreateIndex, but got '%s'", ddl.SQL())
+		}
+	}
+
+	return &SpannerLoaderFromDDL{tables: tables}, nil
+}
+
+type table struct {
+	createTable   *parser.CreateTable
+	createIndexes []*parser.CreateIndex
+}
+
+type SpannerLoaderFromDDL struct {
+	tables map[string]table
+}
+
+func (s *SpannerLoaderFromDDL) ParamN(n int) string {
+	return fmt.Sprintf("@param%d", n)
+}
+
+func (s *SpannerLoaderFromDDL) MaskFunc() string {
+	return "?"
+}
+
+func (s *SpannerLoaderFromDDL) ParseType(dt string, nullable bool) (int, string, string) {
+	return SpanParseType(dt, nullable)
+}
+
+func (s *SpannerLoaderFromDDL) ValidCustomType(dataType string, customType string) bool {
+	return SpanValidateCustomType(dataType, customType)
+}
+
+func (s *SpannerLoaderFromDDL) TableList() ([]*models.Table, error) {
+	var tables []*models.Table
+	for _, t := range s.tables {
+		tables = append(tables, &models.Table{
+			TableName: t.createTable.Name.Name,
+			ManualPk:  true,
+		})
+	}
+
+	return tables, nil
+}
+
+func (s *SpannerLoaderFromDDL) ColumnList(name string) ([]*models.Column, error) {
+	var cols []*models.Column
+	table := s.tables[name].createTable
+
+	check := make(map[string]struct{})
+	for _, pk := range table.PrimaryKeys {
+		check[pk.Name.Name] = struct{}{}
+	}
+
+	for i, c := range table.Columns {
+		_, pk := check[c.Name.Name]
+		cols = append(cols, &models.Column{
+			FieldOrdinal: i + 1,
+			ColumnName:   c.Name.Name,
+			DataType:     c.Type.SQL(),
+			NotNull:      c.NotNull,
+			IsPrimaryKey: pk,
+		})
+	}
+
+	return cols, nil
+}
+
+func (s *SpannerLoaderFromDDL) IndexList(name string) ([]*models.Index, error) {
+	var indexes []*models.Index
+	for _, index := range s.tables[name].createIndexes {
+		indexes = append(indexes, &models.Index{
+			IndexName: index.Name.Name,
+			IsUnique:  index.Unique,
+		})
+	}
+
+	return indexes, nil
+}
+
+func (s *SpannerLoaderFromDDL) IndexColumnList(table, index string) ([]*models.IndexColumn, error) {
+	var cols []*models.IndexColumn
+	for _, ix := range s.tables[table].createIndexes {
+		if ix.Name.Name != index {
+			continue
+		}
+
+		for i, c := range ix.Keys {
+			cols = append(cols, &models.IndexColumn{
+				SeqNo:      i + 1,
+				ColumnName: c.Name.Name,
+			})
+		}
+		break
+	}
+
+	return cols, nil
+}


### PR DESCRIPTION
Generate Go code from DDL file.

This subcommand generates Go code without spanner instance.

Add testdata whose column has OPTIONS.
`cloud.google.com/go/spanner/spansql` can't parse such columns.