### PR TITLE
Use fake spanner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,23 +3,10 @@ version: 2
 jobs:
   test:
     docker:
-      - image: golang:1.11.1-stretch
-        environment:
-          # those environment variables are came from Circle CI settings
-          # SPANNER_PROJECT_NAME: foobar-project
-          # SPANNER_INSTANCE_NAME: foobar-instance
-          # SPANNER_DATABASE_NAME: yo-test
-          GOOGLE_APPLICATION_CREDENTIALS: /credential
-
+      - image: golang:1.13-stretch
     working_directory: /go/src/go.mercari.io/yo
-    resource_class: xlarge
     steps:
       - checkout
-      - run:
-          name: setup service account
-          command: |
-            echo ${GOOGLE_SERVICE_ACCOUNT_DATA} | base64 -d > ${GOOGLE_APPLICATION_CREDENTIALS}
-
       - run:
           name: install deps
           command: |
@@ -38,24 +25,58 @@ jobs:
             git diff --quiet tplbin/
 
       - run:
-          name: regenerate testdata and check diff
-          command: |
-            make testdata YOBIN=./yo
-            git diff --quiet test/
-
-      - run:
           name: regenerate template files and check diff
           command: |
             make recreate-templates YOBIN=./yo
             git diff --quiet templates/
 
       - run:
-          name: run integration test
+          name: run integration test with fake spanner server
           command: |
             make test
+
+  e2etest:
+    docker:
+      - image: golang:1.13-stretch
+        environment:
+          # those environment variables are came from Circle CI settings
+          # SPANNER_PROJECT_NAME: foobar-project
+          # SPANNER_INSTANCE_NAME: foobar-instance
+          # SPANNER_DATABASE_NAME: yo-test
+          GOOGLE_APPLICATION_CREDENTIALS: /credential
+
+    working_directory: /go/src/go.mercari.io/yo
+    steps:
+      - checkout
+      - run:
+          name: setup service account
+          command: |
+            echo ${GOOGLE_SERVICE_ACCOUNT_DATA} | base64 -d > ${GOOGLE_APPLICATION_CREDENTIALS}
+
+      - run:
+          name: install deps
+          command: |
+            make deps
+            dep ensure -vendor-only
+
+      - run:
+          name: regenerate testdata and check diff
+          command: |
+            make testdata YOBIN=./yo
+            git diff --quiet test/
+
+      - run:
+          name: run integration test
+          command: |
+            make e2etest
 
 workflows:
   version: 2
   build-workflow:
     jobs:
       - test
+      - e2etest:
+          filters:
+            branches:
+              only:
+                - master

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,35 @@
 
 
 [[projects]]
-  digest = "1:7ba0512d9bb7c3b4915880d5a011acc60be7f3da7914a4aa001ac8bb864514e8"
+  digest = "1:78aa857341951f21eab811e25663d4ab83c3c13a4db6e3619b9363f456808d12"
   name = "cloud.google.com/go"
   packages = [
+    ".",
     "civil",
     "compute/metadata",
     "internal/fields",
     "internal/protostruct",
     "internal/trace",
-    "internal/version",
+    "longrunning",
+    "longrunning/autogen",
     "spanner",
+    "spanner/admin/database/apiv1",
     "spanner/apiv1",
     "spanner/internal/backoff",
-    "spanner/internal/testutil",
+    "spanner/spannertest",
+    "spanner/spansql",
   ]
   pruneopts = "UT"
-  revision = "cdaaf98f9226c39dc162b8e55083b2fbc67b4674"
-  version = "v0.43.0"
+  revision = "6e28f1c34522dae46e9c37119b78c54471b13ac8"
+  version = "v0.46.2"
+
+[[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
 
 [[projects]]
   branch = "master"
@@ -29,11 +41,24 @@
   revision = "16278e9db8130ac7ec405dc174cfb94344f16325"
 
 [[projects]]
-  digest = "1:c9cffc5a4ef5aa7271985801928f30f19b4d87ce98fea5fee278821ce07a2a4c"
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "869f871628b6baa9cfbc11732cdf6546b17c1298"
+
+[[projects]]
+  digest = "1:8880895d6ff5cd32d648520d7045aec914a40fbb765f0e66860bede9334c981c"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go",
     "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/grpc",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -46,7 +71,7 @@
   version = "v1.3.2"
 
 [[projects]]
-  digest = "1:bf40199583e5143d1472fc34d10d6f4b69d97572142acf343b3e43136da40823"
+  digest = "1:1d1cbf539d9ac35eb3148129f96be5537f1a1330cadcc7e3a83b4e72a59672a3"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
@@ -56,8 +81,8 @@
     "cmp/internal/value",
   ]
   pruneopts = "UT"
-  revision = "6f77996f0c42f7b84e5a2b252227263f93432e9b"
-  version = "v0.3.0"
+  revision = "2d0692c2e9617365a95b295612ac0d4415ba4627"
+  version = "v0.3.1"
 
 [[projects]]
   digest = "1:766102087520f9d54f2acc72bd6637045900ac735b4a419b128d216f0c5c4876"
@@ -66,14 +91,6 @@
   pruneopts = "UT"
   revision = "bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2"
   version = "v2.0.5"
-
-[[projects]]
-  digest = "1:7fae9ec96d10b2afce0da23c378c8b3389319b7f92fa092f2621bba3078cfb4b"
-  name = "github.com/hashicorp/golang-lru"
-  packages = ["simplelru"]
-  pruneopts = "UT"
-  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
-  version = "v0.5.3"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -90,6 +107,18 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "4f4301a06e153ff90e17793577ab6bf79f8dc5c5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:89e34854f4513cb0c53ada9ba52e680b8b74a370b33b3a26800a4cdbc9f00ced"
+  name = "github.com/jstemmer/go-junit-report"
+  packages = [
+    ".",
+    "formatter",
+    "parser",
+  ]
+  pruneopts = "UT"
+  revision = "af01ea7f8024089b458d804d5cdf190f962a9a0c"
 
 [[projects]]
   branch = "master"
@@ -116,7 +145,7 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:bf33f7cd985e8e62eeef3b1985ec48f0f274e4083fa811596aafaf3af2947e83"
+  digest = "1:07ca513e3b295b9aeb1f0f6fbefb8102139a2764ce0f28d02040c0eb2dc276dd"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -138,12 +167,34 @@
     "trace/tracestate",
   ]
   pruneopts = "UT"
-  revision = "9c377598961b706d1542bd2d84d538b5094d596e"
-  version = "v0.22.0"
+  revision = "59d1ce35d30f3c25ba762169da2a37eab6ffa041"
+  version = "v0.22.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:eae689808191546269bf951e1e66e0b6bc468be58a0498c0f037feeef2c67bab"
+  digest = "1:691f3a202dd569bd0d33b8b16bcb390a479b3c6ccc8ced9cb13085e47030e11a"
+  name = "golang.org/x/exp"
+  packages = [
+    "apidiff",
+    "cmd/apidiff",
+  ]
+  pruneopts = "UT"
+  revision = "ac5d2bfcbfe092bf8a1233e37c03571b3047d81b"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8b680f1201926e744b91715dda339a799fcc9a37e3a9c6d742bf90b4a6e7e6de"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = "UT"
+  revision = "414d861bb4acf565ff8cb05f9906a2283b7dc75a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:7a4eaae8773e8fccca11c5c60d5393235e2dc880356f1dc6bc753b114f17e0e6"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -156,7 +207,7 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "ca1201d0de80cfde86cb01aea620983605dfe99b"
+  revision = "24e19bdeb0f2d062d8e2640d50a7aaf2a7f80e7a"
 
 [[projects]]
   branch = "master"
@@ -174,11 +225,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ec99dad7924bf972656818f5d62216fb987b7e077d401deb86b3c1e5e1b1d4d6"
+  digest = "1:31ca8823684b4b0c204df1d4a9f3c511f41cc3e7ab6decc2ca5ffacc358d2818"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "fc99dfbffb4e5ed5758a37e31dd861afe285406b"
+  revision = "c3b328c6e5a763a2bfc82a48b4bd855037210934"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -207,6 +258,31 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:2958bdacee682ff346b1751d176036a577969d165535f3b682b3177fa81bf614"
+  name = "golang.org/x/tools"
+  packages = [
+    "cmd/goimports",
+    "go/analysis",
+    "go/analysis/passes/inspect",
+    "go/ast/astutil",
+    "go/ast/inspector",
+    "go/buildutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/objectpath",
+    "go/types/typeutil",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/imports",
+    "internal/module",
+    "internal/semver",
+  ]
+  pruneopts = "UT"
+  revision = "0240832f5c3d9ddcdcd51c66edbf8cd889a54108"
+
+[[projects]]
   digest = "1:341d8e5c30ab07533e4a9a5c0203138160984e2553415e9cb5d113fe31185800"
   name = "google.golang.org/api"
   packages = [
@@ -222,7 +298,8 @@
     "transport/http/internal/propagation",
   ]
   pruneopts = "UT"
-  revision = "06fc85c7ff4e467512a7a90976394114836b85da"
+  revision = "09a9d0a772eb18da65a7917760cf4ca9ae943c83"
+  version = "v0.10.0"
 
 [[projects]]
   digest = "1:2c26b1c47556c0e5e73cdb05d8361c463737eee4baac35d38b40c728c3074a94"
@@ -242,25 +319,29 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
-  version = "v1.6.1"
+  revision = "5f2a59506353b8d5ba8cbbcd9f3c1f41f1eaf079"
+  version = "v1.6.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:9eac501cf588447be89929159bdf80ab886f3a12e88ced1228eaa7acb21a275b"
+  digest = "1:155a1e24243c6a00d8a984a3144c32822c74824095d2c15522d6e30a00e1b2c1"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
+    "googleapis/iam/v1",
+    "googleapis/longrunning",
     "googleapis/rpc/code",
     "googleapis/rpc/errdetails",
     "googleapis/rpc/status",
+    "googleapis/spanner/admin/database/v1",
     "googleapis/spanner/v1",
+    "googleapis/type/expr",
   ]
   pruneopts = "UT"
-  revision = "c506a9f9061087022822e8da603a52fc387115a8"
+  revision = "1774047e7e5133fa3573a4e51b37a586b6b0360c"
 
 [[projects]]
-  digest = "1:01b9d0e52a1c429a4654d90fe3ddd9711b743469869284bffb1c949200c14cdc"
+  digest = "1:e247c7cd32bd883b82930de2bf456d8e6ce62f2116f95adbb18e8438071f4bf6"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -309,8 +390,8 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "045159ad57f3781d409358e3ade910a018c16b30"
-  version = "v1.22.1"
+  revision = "39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6"
+  version = "v1.23.1"
 
 [[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
@@ -320,18 +401,56 @@
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
+[[projects]]
+  digest = "1:131158a88aad1f94854d0aa21a64af2802d0a470fb0f01cb33c04fafd2047111"
+  name = "honnef.co/go/tools"
+  packages = [
+    "arg",
+    "cmd/staticcheck",
+    "config",
+    "deprecated",
+    "facts",
+    "functions",
+    "go/types/typeutil",
+    "internal/cache",
+    "internal/passes/buildssa",
+    "internal/renameio",
+    "internal/sharedcheck",
+    "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "loader",
+    "printf",
+    "simple",
+    "ssa",
+    "ssautil",
+    "staticcheck",
+    "staticcheck/vrp",
+    "stylecheck",
+    "unused",
+    "version",
+  ]
+  pruneopts = "UT"
+  revision = "afd67930eec2a9ed3e9b19f684d17a062285f16a"
+  version = "2019.2.3"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "cloud.google.com/go/civil",
     "cloud.google.com/go/spanner",
+    "cloud.google.com/go/spanner/admin/database/apiv1",
+    "cloud.google.com/go/spanner/spannertest",
     "github.com/gedex/inflector",
     "github.com/google/go-cmp/cmp",
     "github.com/jessevdk/go-assets",
     "github.com/knq/snaker",
     "github.com/spf13/cobra",
     "google.golang.org/api/iterator",
+    "google.golang.org/api/option",
+    "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/status",
     "gopkg.in/yaml.v2",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.43.0"
+  version = ">=0.46.0"
 
 [[constraint]]
   branch = "master"
@@ -11,8 +11,8 @@
   name = "github.com/knq/snaker"
 
 [[constraint]]
-  branch = "master"
   name = "google.golang.org/api"
+  version = ">=0.10.0"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ tplbin/templates.go: $(wildcard templates/*.tpl)
 
 .PHONY: test
 test:
+	@echo run tests with fake spanner server
+	go test -race -v -short ./test
+
+e2etest:
+	@echo run tests with real spanner server
 	go test -race -v ./test
 
 testsetup:

--- a/test/testutil/data.go
+++ b/test/testutil/data.go
@@ -1,0 +1,135 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	dbadmin "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/spannertest"
+	"google.golang.org/api/option"
+	dbadminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+	"google.golang.org/grpc"
+)
+
+func DeleteAllData(ctx context.Context, client *spanner.Client) error {
+	tables := []string{
+		"CompositePrimaryKeys",
+		"FullTypes",
+		"MaxLengths",
+		"snake_cases",
+	}
+	var muts []*spanner.Mutation
+	for _, table := range tables {
+		muts = append(muts, spanner.Delete(table, spanner.AllKeys()))
+	}
+
+	if _, err := client.Apply(ctx, muts, spanner.ApplyAtLeastOnce()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetupFakeSpanner runs fake spanner server and create clients for the server.
+// Please make sure to call stop func to stop the server and the clients.
+func SetupFakeSpanner(ctx context.Context, dbname string) (*spanner.Client, *dbadmin.DatabaseAdminClient, func(), error) {
+	srv, err := spannertest.NewServer("localhost:0")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to start fake spanner server: %v", err)
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(dialCtx, srv.Addr, grpc.WithInsecure())
+	if err != nil {
+		srv.Close()
+		return nil, nil, nil, fmt.Errorf("dialing to fake spanner server failed: %v", err)
+	}
+
+	client, err := spanner.NewClient(ctx, dbname, option.WithGRPCConn(conn))
+	if err != nil {
+		srv.Close()
+		conn.Close()
+		return nil, nil, nil, fmt.Errorf("creating spanner client: %v", err)
+	}
+	adminClient, err := dbadmin.NewDatabaseAdminClient(ctx, option.WithGRPCConn(conn))
+	if err != nil {
+		srv.Close()
+		conn.Close()
+		return nil, nil, nil, fmt.Errorf("creating spanner admin client: %v", err)
+	}
+
+	stop := func() {
+		srv.Close()
+		conn.Close()
+	}
+
+	return client, adminClient, stop, nil
+}
+
+// ApplyDDL applies DDL statements and waits until finished.
+func ApplyDDL(ctx context.Context, adminClient *dbadmin.DatabaseAdminClient, dbname string, statements ...string) error {
+	op, err := adminClient.UpdateDatabaseDdl(ctx, &dbadminpb.UpdateDatabaseDdlRequest{
+		Database:   dbname,
+		Statements: statements,
+	})
+	if err != nil {
+		return fmt.Errorf("apply DDL failed: %v", err)
+	}
+	return op.Wait(ctx)
+}
+
+func findProjectRootDir() string {
+	dir, _ := os.Getwd()
+	for {
+		next := filepath.Dir(dir)
+		if dir == next {
+			panic("cannot find project root")
+		}
+
+		if filepath.Base(dir) == "yo" {
+			break
+		}
+
+		dir = next
+	}
+
+	return dir
+}
+
+// ApplyTestScheme applies test schema in testdata.
+func ApplyTestSchema(ctx context.Context, adminClient *dbadmin.DatabaseAdminClient, dbname string) error {
+	dir := findProjectRootDir()
+
+	// Open test schema
+	file, err := os.Open(filepath.Join(dir, "./test/testdata/schema.sql"))
+	if err != nil {
+		return fmt.Errorf("scheme file cannot open: %v", err)
+	}
+
+	b, err := ioutil.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("read error: %v", err)
+	}
+
+	// Split scheme definition to DDL statements.
+	// This assuemes there is no comments and each statement is separated by semi-colon
+	var statements []string
+	for _, s := range strings.Split(string(b), ";") {
+		s = strings.TrimSpace(s)
+		if len(s) == 0 {
+			continue
+		}
+		statements = append(statements, s)
+	}
+
+	// Apply DDL statements to create tables
+	return ApplyDDL(ctx, adminClient, dbname, statements...)
+}


### PR DESCRIPTION
A fake spanner server has recently been introduced in google-cloug-go repo. It does not fully support all features of spanner, but simple operations are supported. If we can use a fake server, we don't need a real spanner server for testing.

For now we use a fake spanner server for tests partially. When we run tests with short option, it runs with a fake spanner server. `make test` runs with short option. The original behavior is run as `make e2etest`.

Additionally I enable CI for forked pull requests. It was disabled because of problems of secrets. The CI for forked pull requests runs tests that does not need tokens, which means tests don't require a real spanner. Tests that requires a real spanner runs only on master branch. Of course secrets are not populated in CIs for forked PRs.