### PR TITLE
add TableMap to basicDataSet

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -109,7 +109,8 @@ func (g *Generator) Generate(tableMap map[string]*internal.Type, ixMap map[strin
 	}
 
 	ds := &basicDataSet{
-		Package: g.packageName,
+		Package:  g.packageName,
+		TableMap: tableMap,
 	}
 
 	if err := g.ExecuteTemplate(YOTemplate, "yo_db", "", ds); err != nil {

--- a/generator/templates.go
+++ b/generator/templates.go
@@ -3,6 +3,8 @@ package generator
 import (
 	"io"
 	"text/template"
+
+	"go.mercari.io/yo/internal"
 )
 
 // TemplateType represents a template type.
@@ -90,7 +92,8 @@ var (
 
 // basicDataSet is used for template data for yo_db and yo_package.
 type basicDataSet struct {
-	Package string
+	Package  string
+	TableMap map[string]*internal.Type
 }
 
 // templateSet is a set of templates.


### PR DESCRIPTION
Hello!
Thank you awesome software.

I want to generate code like below for tools.
```
var (
    tables = []string{
        "a",
        "b",
    }
)

func SomethingAll() {
      for _, table := range tables {
        switch table {
        case "a":
            t := A{}
            t.Something()

        case "b":
            t := B{}
            t.Something()
        }
    }
}
```
I think current yo version cannot generate such code.
(Sorry if it can be.)
But I'm not sure whether adding tableMap to basicDataSet is bad design yo's design policy.

Please Review this.

---
I agreed CLA.

https://www.mercari.com/cla/
