### PR TITLE
BREAKING :warning: Fix handling of storing columns

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -260,6 +260,9 @@ func (tl *TypeLoader) buildIndexFuncName(ixTpl *Index) string {
 
 	// add param names
 	paramNames := make([]string, 0, len(ixTpl.Fields))
+	for _, f := range ixTpl.StoringFields {
+		paramNames = append(paramNames, f.Name)
+	}
 	for _, f := range ixTpl.Fields {
 		paramNames = append(paramNames, f.Name)
 	}
@@ -294,7 +297,12 @@ func (tl *TypeLoader) LoadIndexColumns(args *ArgType, ixTpl *Index) error {
 			continue
 		}
 
-		ixTpl.Fields = append(ixTpl.Fields, field)
+		if ic.Storing {
+			// Storing column is added to StoringFields
+			ixTpl.StoringFields = append(ixTpl.Fields, field)
+		} else {
+			ixTpl.Fields = append(ixTpl.Fields, field)
+		}
 	}
 
 	return nil

--- a/internal/types.go
+++ b/internal/types.go
@@ -24,9 +24,10 @@ type Type struct {
 
 // Index is a template item for a index into a table.
 type Index struct {
-	FuncName string
-	Schema   string
-	Type     *Type
-	Fields   []*Field
-	Index    *models.Index
+	FuncName      string
+	Schema        string
+	Type          *Type
+	Fields        []*Field
+	StoringFields []*Field
+	Index         *models.Index
 }

--- a/loaders/parser.go
+++ b/loaders/parser.go
@@ -129,6 +129,17 @@ func (s *SpannerLoaderFromDDL) IndexColumnList(table, index string) ([]*models.I
 			continue
 		}
 
+		// add storing columns first
+		if ix.Storing != nil {
+			for _, c := range ix.Storing.Columns {
+				cols = append(cols, &models.IndexColumn{
+					SeqNo:      0,
+					Storing:    true,
+					ColumnName: c.Name,
+				})
+			}
+		}
+
 		for i, c := range ix.Keys {
 			cols = append(cols, &models.IndexColumn{
 				SeqNo:      i + 1,

--- a/loaders/spanner.go
+++ b/loaders/spanner.go
@@ -343,6 +343,9 @@ func SpanIndexColumns(client *spanner.Client, table string, index string) ([]*mo
 			return nil, err
 		}
 		i.SeqNo = int(ord.Int64)
+		if !ord.Valid {
+			i.Storing = true
+		}
 		if err := row.ColumnByName("COLUMN_NAME", &i.ColumnName); err != nil {
 			return nil, err
 		}

--- a/models/model.go
+++ b/models/model.go
@@ -28,9 +28,9 @@ type Index struct {
 
 // IndexColumn represents index column info.
 type IndexColumn struct {
-	SeqNo      int    // seq_no
-	Cid        int    // cid
+	SeqNo      int    // seq_no. If is'a Storing Column, this value is 0.
 	ColumnName string // column_name
+	Storing    bool   // storing column or not
 }
 
 // CustomTypes represents custom type definitions

--- a/test/testdata/schema.sql
+++ b/test/testdata/schema.sql
@@ -8,8 +8,10 @@ CREATE TABLE CompositePrimaryKeys (
   Z STRING(32) NOT NULL,
 ) PRIMARY KEY(PKey1, PKey2);
 
-CREATE INDEX CompositePrimaryKeysByXY ON CompositePrimaryKeys(X, Y);
+CREATE INDEX CompositePrimaryKeysByXY     ON CompositePrimaryKeys(X, Y);
 CREATE INDEX CompositePrimaryKeysByError  ON CompositePrimaryKeys(Error);
+CREATE INDEX CompositePrimaryKeysByError2 ON CompositePrimaryKeys(Error) STORING(Z);
+CREATE INDEX CompositePrimaryKeysByError3 ON CompositePrimaryKeys(Error) STORING(Z, Y);
 
 CREATE TABLE FullTypes (
   PKey STRING(32) NOT NULL,

--- a/test/testmodels/customtypes/compositeprimarykey.yo.go
+++ b/test/testmodels/customtypes/compositeprimarykey.yo.go
@@ -232,20 +232,19 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YORODB, e int8) ([]
 // FindCompositePrimaryKeysByZError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByError2'.
-func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, e int8) ([]*CompositePrimaryKey, error) {
+func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, e int8) ([]*CompositePrimaryKey, error) {
 	const sqlstr = "SELECT " +
 		"Id, PKey1, PKey2, Error, X, Y, Z " +
 		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError2} " +
-		"WHERE Z = @param0 AND Error = @param1"
+		"WHERE Error = @param0"
 
 	stmt := spanner.NewStatement(sqlstr)
-	stmt.Params["param0"] = z
-	stmt.Params["param1"] = int64(e)
+	stmt.Params["param0"] = int64(e)
 
 	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
 
 	// run query
-	YOLog(ctx, sqlstr, z, e)
+	YOLog(ctx, sqlstr, e)
 	iter := db.Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -271,24 +270,22 @@ func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, 
 	return res, nil
 }
 
-// FindCompositePrimaryKeysByZYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+// FindCompositePrimaryKeysByYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByError3'.
-func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string, y string, e int8) ([]*CompositePrimaryKey, error) {
+func FindCompositePrimaryKeysByYError(ctx context.Context, db YORODB, e int8) ([]*CompositePrimaryKey, error) {
 	const sqlstr = "SELECT " +
 		"Id, PKey1, PKey2, Error, X, Y, Z " +
 		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError3} " +
-		"WHERE Z = @param0 AND Y = @param1 AND Error = @param2"
+		"WHERE Error = @param0"
 
 	stmt := spanner.NewStatement(sqlstr)
-	stmt.Params["param0"] = z
-	stmt.Params["param1"] = y
-	stmt.Params["param2"] = int64(e)
+	stmt.Params["param0"] = int64(e)
 
 	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
 
 	// run query
-	YOLog(ctx, sqlstr, z, y, e)
+	YOLog(ctx, sqlstr, e)
 	iter := db.Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -300,12 +297,12 @@ func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string,
 			if err == iterator.Done {
 				break
 			}
-			return nil, newError("FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+			return nil, newError("FindCompositePrimaryKeysByYError", "CompositePrimaryKeys", err)
 		}
 
 		cpk, err := decoder(row)
 		if err != nil {
-			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByYError", "CompositePrimaryKeys", err)
 		}
 
 		res = append(res, cpk)

--- a/test/testmodels/customtypes/compositeprimarykey.yo.go
+++ b/test/testmodels/customtypes/compositeprimarykey.yo.go
@@ -229,6 +229,91 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YORODB, e int8) ([]
 	return res, nil
 }
 
+// FindCompositePrimaryKeysByZError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+//
+// Generated from index 'CompositePrimaryKeysByError2'.
+func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, e int8) ([]*CompositePrimaryKey, error) {
+	const sqlstr = "SELECT " +
+		"Id, PKey1, PKey2, Error, X, Y, Z " +
+		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError2} " +
+		"WHERE Z = @param0 AND Error = @param1"
+
+	stmt := spanner.NewStatement(sqlstr)
+	stmt.Params["param0"] = z
+	stmt.Params["param1"] = int64(e)
+
+	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
+
+	// run query
+	YOLog(ctx, sqlstr, z, e)
+	iter := db.Query(ctx, stmt)
+	defer iter.Stop()
+
+	// load results
+	res := []*CompositePrimaryKey{}
+	for {
+		row, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, newError("FindCompositePrimaryKeysByZError", "CompositePrimaryKeys", err)
+		}
+
+		cpk, err := decoder(row)
+		if err != nil {
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZError", "CompositePrimaryKeys", err)
+		}
+
+		res = append(res, cpk)
+	}
+
+	return res, nil
+}
+
+// FindCompositePrimaryKeysByZYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+//
+// Generated from index 'CompositePrimaryKeysByError3'.
+func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string, y string, e int8) ([]*CompositePrimaryKey, error) {
+	const sqlstr = "SELECT " +
+		"Id, PKey1, PKey2, Error, X, Y, Z " +
+		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError3} " +
+		"WHERE Z = @param0 AND Y = @param1 AND Error = @param2"
+
+	stmt := spanner.NewStatement(sqlstr)
+	stmt.Params["param0"] = z
+	stmt.Params["param1"] = y
+	stmt.Params["param2"] = int64(e)
+
+	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
+
+	// run query
+	YOLog(ctx, sqlstr, z, y, e)
+	iter := db.Query(ctx, stmt)
+	defer iter.Stop()
+
+	// load results
+	res := []*CompositePrimaryKey{}
+	for {
+		row, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, newError("FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+		}
+
+		cpk, err := decoder(row)
+		if err != nil {
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+		}
+
+		res = append(res, cpk)
+	}
+
+	return res, nil
+}
+
 // FindCompositePrimaryKeysByXY retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByXY'.

--- a/test/testmodels/default/compositeprimarykey.yo.go
+++ b/test/testmodels/default/compositeprimarykey.yo.go
@@ -222,20 +222,19 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YORODB, e int64) ([
 // FindCompositePrimaryKeysByZError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByError2'.
-func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, e int64) ([]*CompositePrimaryKey, error) {
+func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, e int64) ([]*CompositePrimaryKey, error) {
 	const sqlstr = "SELECT " +
 		"Id, PKey1, PKey2, Error, X, Y, Z " +
 		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError2} " +
-		"WHERE Z = @param0 AND Error = @param1"
+		"WHERE Error = @param0"
 
 	stmt := spanner.NewStatement(sqlstr)
-	stmt.Params["param0"] = z
-	stmt.Params["param1"] = e
+	stmt.Params["param0"] = e
 
 	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
 
 	// run query
-	YOLog(ctx, sqlstr, z, e)
+	YOLog(ctx, sqlstr, e)
 	iter := db.Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -261,24 +260,22 @@ func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, 
 	return res, nil
 }
 
-// FindCompositePrimaryKeysByZYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+// FindCompositePrimaryKeysByYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByError3'.
-func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string, y string, e int64) ([]*CompositePrimaryKey, error) {
+func FindCompositePrimaryKeysByYError(ctx context.Context, db YORODB, e int64) ([]*CompositePrimaryKey, error) {
 	const sqlstr = "SELECT " +
 		"Id, PKey1, PKey2, Error, X, Y, Z " +
 		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError3} " +
-		"WHERE Z = @param0 AND Y = @param1 AND Error = @param2"
+		"WHERE Error = @param0"
 
 	stmt := spanner.NewStatement(sqlstr)
-	stmt.Params["param0"] = z
-	stmt.Params["param1"] = y
-	stmt.Params["param2"] = e
+	stmt.Params["param0"] = e
 
 	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
 
 	// run query
-	YOLog(ctx, sqlstr, z, y, e)
+	YOLog(ctx, sqlstr, e)
 	iter := db.Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -290,12 +287,12 @@ func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string,
 			if err == iterator.Done {
 				break
 			}
-			return nil, newError("FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+			return nil, newError("FindCompositePrimaryKeysByYError", "CompositePrimaryKeys", err)
 		}
 
 		cpk, err := decoder(row)
 		if err != nil {
-			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByYError", "CompositePrimaryKeys", err)
 		}
 
 		res = append(res, cpk)

--- a/test/testmodels/default/compositeprimarykey.yo.go
+++ b/test/testmodels/default/compositeprimarykey.yo.go
@@ -219,6 +219,91 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YORODB, e int64) ([
 	return res, nil
 }
 
+// FindCompositePrimaryKeysByZError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+//
+// Generated from index 'CompositePrimaryKeysByError2'.
+func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, e int64) ([]*CompositePrimaryKey, error) {
+	const sqlstr = "SELECT " +
+		"Id, PKey1, PKey2, Error, X, Y, Z " +
+		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError2} " +
+		"WHERE Z = @param0 AND Error = @param1"
+
+	stmt := spanner.NewStatement(sqlstr)
+	stmt.Params["param0"] = z
+	stmt.Params["param1"] = e
+
+	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
+
+	// run query
+	YOLog(ctx, sqlstr, z, e)
+	iter := db.Query(ctx, stmt)
+	defer iter.Stop()
+
+	// load results
+	res := []*CompositePrimaryKey{}
+	for {
+		row, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, newError("FindCompositePrimaryKeysByZError", "CompositePrimaryKeys", err)
+		}
+
+		cpk, err := decoder(row)
+		if err != nil {
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZError", "CompositePrimaryKeys", err)
+		}
+
+		res = append(res, cpk)
+	}
+
+	return res, nil
+}
+
+// FindCompositePrimaryKeysByZYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+//
+// Generated from index 'CompositePrimaryKeysByError3'.
+func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string, y string, e int64) ([]*CompositePrimaryKey, error) {
+	const sqlstr = "SELECT " +
+		"Id, PKey1, PKey2, Error, X, Y, Z " +
+		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError3} " +
+		"WHERE Z = @param0 AND Y = @param1 AND Error = @param2"
+
+	stmt := spanner.NewStatement(sqlstr)
+	stmt.Params["param0"] = z
+	stmt.Params["param1"] = y
+	stmt.Params["param2"] = e
+
+	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
+
+	// run query
+	YOLog(ctx, sqlstr, z, y, e)
+	iter := db.Query(ctx, stmt)
+	defer iter.Stop()
+
+	// load results
+	res := []*CompositePrimaryKey{}
+	for {
+		row, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, newError("FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+		}
+
+		cpk, err := decoder(row)
+		if err != nil {
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+		}
+
+		res = append(res, cpk)
+	}
+
+	return res, nil
+}
+
 // FindCompositePrimaryKeysByXY retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByXY'.

--- a/test/testmodels/single/single_file.go
+++ b/test/testmodels/single/single_file.go
@@ -801,20 +801,19 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YORODB, e int64) ([
 // FindCompositePrimaryKeysByZError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByError2'.
-func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, e int64) ([]*CompositePrimaryKey, error) {
+func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, e int64) ([]*CompositePrimaryKey, error) {
 	const sqlstr = "SELECT " +
 		"Id, PKey1, PKey2, Error, X, Y, Z " +
 		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError2} " +
-		"WHERE Z = @param0 AND Error = @param1"
+		"WHERE Error = @param0"
 
 	stmt := spanner.NewStatement(sqlstr)
-	stmt.Params["param0"] = z
-	stmt.Params["param1"] = e
+	stmt.Params["param0"] = e
 
 	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
 
 	// run query
-	YOLog(ctx, sqlstr, z, e)
+	YOLog(ctx, sqlstr, e)
 	iter := db.Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -840,24 +839,22 @@ func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, 
 	return res, nil
 }
 
-// FindCompositePrimaryKeysByZYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+// FindCompositePrimaryKeysByYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByError3'.
-func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string, y string, e int64) ([]*CompositePrimaryKey, error) {
+func FindCompositePrimaryKeysByYError(ctx context.Context, db YORODB, e int64) ([]*CompositePrimaryKey, error) {
 	const sqlstr = "SELECT " +
 		"Id, PKey1, PKey2, Error, X, Y, Z " +
 		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError3} " +
-		"WHERE Z = @param0 AND Y = @param1 AND Error = @param2"
+		"WHERE Error = @param0"
 
 	stmt := spanner.NewStatement(sqlstr)
-	stmt.Params["param0"] = z
-	stmt.Params["param1"] = y
-	stmt.Params["param2"] = e
+	stmt.Params["param0"] = e
 
 	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
 
 	// run query
-	YOLog(ctx, sqlstr, z, y, e)
+	YOLog(ctx, sqlstr, e)
 	iter := db.Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -869,12 +866,12 @@ func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string,
 			if err == iterator.Done {
 				break
 			}
-			return nil, newError("FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+			return nil, newError("FindCompositePrimaryKeysByYError", "CompositePrimaryKeys", err)
 		}
 
 		cpk, err := decoder(row)
 		if err != nil {
-			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByYError", "CompositePrimaryKeys", err)
 		}
 
 		res = append(res, cpk)

--- a/test/testmodels/single/single_file.go
+++ b/test/testmodels/single/single_file.go
@@ -798,6 +798,91 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YORODB, e int64) ([
 	return res, nil
 }
 
+// FindCompositePrimaryKeysByZError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+//
+// Generated from index 'CompositePrimaryKeysByError2'.
+func FindCompositePrimaryKeysByZError(ctx context.Context, db YORODB, z string, e int64) ([]*CompositePrimaryKey, error) {
+	const sqlstr = "SELECT " +
+		"Id, PKey1, PKey2, Error, X, Y, Z " +
+		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError2} " +
+		"WHERE Z = @param0 AND Error = @param1"
+
+	stmt := spanner.NewStatement(sqlstr)
+	stmt.Params["param0"] = z
+	stmt.Params["param1"] = e
+
+	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
+
+	// run query
+	YOLog(ctx, sqlstr, z, e)
+	iter := db.Query(ctx, stmt)
+	defer iter.Stop()
+
+	// load results
+	res := []*CompositePrimaryKey{}
+	for {
+		row, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, newError("FindCompositePrimaryKeysByZError", "CompositePrimaryKeys", err)
+		}
+
+		cpk, err := decoder(row)
+		if err != nil {
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZError", "CompositePrimaryKeys", err)
+		}
+
+		res = append(res, cpk)
+	}
+
+	return res, nil
+}
+
+// FindCompositePrimaryKeysByZYError retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
+//
+// Generated from index 'CompositePrimaryKeysByError3'.
+func FindCompositePrimaryKeysByZYError(ctx context.Context, db YORODB, z string, y string, e int64) ([]*CompositePrimaryKey, error) {
+	const sqlstr = "SELECT " +
+		"Id, PKey1, PKey2, Error, X, Y, Z " +
+		"FROM CompositePrimaryKeys@{FORCE_INDEX=CompositePrimaryKeysByError3} " +
+		"WHERE Z = @param0 AND Y = @param1 AND Error = @param2"
+
+	stmt := spanner.NewStatement(sqlstr)
+	stmt.Params["param0"] = z
+	stmt.Params["param1"] = y
+	stmt.Params["param2"] = e
+
+	decoder := newCompositePrimaryKey_Decoder(CompositePrimaryKeyColumns())
+
+	// run query
+	YOLog(ctx, sqlstr, z, y, e)
+	iter := db.Query(ctx, stmt)
+	defer iter.Stop()
+
+	// load results
+	res := []*CompositePrimaryKey{}
+	for {
+		row, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, newError("FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+		}
+
+		cpk, err := decoder(row)
+		if err != nil {
+			return nil, newErrorWithCode(codes.Internal, "FindCompositePrimaryKeysByZYError", "CompositePrimaryKeys", err)
+		}
+
+		res = append(res, cpk)
+	}
+
+	return res, nil
+}
+
 // FindCompositePrimaryKeysByXY retrieves multiple rows from 'CompositePrimaryKeys' as a slice of CompositePrimaryKey.
 //
 // Generated from index 'CompositePrimaryKeysByXY'.


### PR DESCRIPTION
When storing columns are used in an index, those columns are recognized as index fields. Invalid code is generarted as a result.

This PR changes:

* Add `StoringFields` field into `internal.Index`
   * This can be referred in a template for index
* Add storing columns into `StoringFields` field instead of `Fields` for `internal.Index` in loader
* `FuncName` in `internal.Index` is generated by `Fields` and `StoringFields`
    * This keeps the compatibility of it's naming

Breaking Change:

* yo generates a function with a different signature for index if it uses storing columns


