### PR TITLE
add Inflection rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Flags:
   -h, --help                         help for yo
       --ignore-fields stringArray    fields to exclude from the generated Go code types
       --ignore-tables stringArray    tables to exclude from the generated Go code types
+      --inflection-rule-file string  custom inflection rule file
   -o, --out string                   output path or file name
   -p, --package string               package name used in generated Go code
       --single-file                  toggle single file output
@@ -182,6 +183,20 @@ templates in the `yo` source tree for use within your own project.
 **This is not a stable feature**
 
 `yo` provides some helper functions which can be used in templates. Those are defined in [`generator/funcs.go`](generator/funcs.go). Those are not well documented and are likely to change.
+
+### Custom Inflection Rule file
+
+`yo` use inflection to convert singular or plural name each other.
+If you want to add own rule, add `--inflection-rule-file` option with rule yaml file.
+rule yaml file sample is
+```
+- singular: person
+  plural: people
+- singular: live
+  plural: lives
+```
+
+See https://github.com/jinzhu/inflection#register-rules for Detail.
 
 ## Contribution
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -37,20 +37,24 @@ var (
 				return err
 			}
 
+			inflector, err := internal.NewInflector(generateOpts.InflectionRuleFile)
+			if err != nil {
+				return fmt.Errorf("load inflection rule failed: %v", err)
+			}
 			var loader *internal.TypeLoader
 			if generateOpts.FromDDL {
 				spannerLoader, err := loaders.NewSpannerLoaderFromDDL(args[0])
 				if err != nil {
 					return fmt.Errorf("error: %v", err)
 				}
-				loader = internal.NewTypeLoader(spannerLoader)
+				loader = internal.NewTypeLoader(spannerLoader, inflector)
 			} else {
 				spannerClient, err := connectSpanner(&rootOpts)
 				if err != nil {
 					return fmt.Errorf("error: %v", err)
 				}
 				spannerLoader := loaders.NewSpannerLoader(spannerClient)
-				loader = internal.NewTypeLoader(spannerLoader)
+				loader = internal.NewTypeLoader(spannerLoader, inflector)
 			}
 
 			// load custom type definitions

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,11 @@ var (
 				return fmt.Errorf("error: %v", err)
 			}
 			spannerLoader := loaders.NewSpannerLoader(spannerClient)
-			loader := internal.NewTypeLoader(spannerLoader)
+			inflector, err := internal.NewInflector(rootOpts.InflectionRuleFile)
+			if err != nil {
+				return fmt.Errorf("load inflection rule failed: %v", err)
+			}
+			loader := internal.NewTypeLoader(spannerLoader, inflector)
 
 			// load custom type definitions
 			if rootOpts.CustomTypesFile != "" {
@@ -102,6 +106,7 @@ func setRootOpts(cmd *cobra.Command, opts *internal.ArgType) {
 	cmd.Flags().StringArrayVar(&opts.IgnoreTables, "ignore-tables", nil, "tables to exclude from the generated Go code types")
 	cmd.Flags().StringVar(&opts.TemplatePath, "template-path", "", "user supplied template path")
 	cmd.Flags().StringVar(&opts.Tags, "tags", "", "build tags to add to package header")
+	cmd.Flags().StringVar(&opts.InflectionRuleFile, "inflection-rule-file", "", "custom inflection rule file")
 
 	helpFn := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
 	github.com/google/go-cmp v0.3.1
 	github.com/jessevdk/go-assets v0.0.0-20160921144138-4f4301a06e15
+	github.com/jinzhu/inflection v1.0.0
 	github.com/knq/snaker v0.0.0-20181215144011-2bc8a4db4687
 	github.com/mattn/go-isatty v0.0.11 // indirect
 	github.com/mattn/go-sqlite3 v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,6 @@ cloud.google.com/go v0.49.0 h1:CH+lkubJzcPYB1Ggupcq0+k8Ni2ILdG2lYjDIgavDBQ=
 cloud.google.com/go v0.49.0/go.mod h1:hGvAdzcWNbyuxS3nWhD7H2cIJxjRRTRLQVB0bdputVY=
 cloud.google.com/go/bigquery v1.0.1 h1:hL+ycaJpVE9M7nLoiXb/Pn10ENE2u+oddxbD8uu0ZVU=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
-cloud.google.com/go/bigquery v1.2.0 h1:5wdyDJgqmqlAqzIhN6hY9E2vqE9M545UVLU1rrSr/x4=
 cloud.google.com/go/bigquery v1.2.0/go.mod h1:Cqg1qaK3wRdys8sKlow0jIBVFwSTiHoFx5um4ujCpyE=
 cloud.google.com/go/bigquery v1.3.0 h1:sAbMqjY1PEQKZBWfbu6Y6bsupJ9c4QdHnzg/VvYTLcE=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -23,7 +22,6 @@ cloud.google.com/go/spanner v1.1.0 h1:hIjiz2Pf6Hy3BWz+Oaw7XUqP+EzWDkj0/DtTkKazxz
 cloud.google.com/go/spanner v1.1.0/go.mod h1:TzTaF9l2ZY2CIetNvVpUu6ZQy8YEOtzB6ICa5EwYjL0=
 cloud.google.com/go/storage v1.0.0 h1:VV2nUM3wwLLGh9lSABFgZMjInyUbJeaRSE64WuAIQ+4=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
-cloud.google.com/go/storage v1.1.2 h1:q7KNypEb3CARnitCAqY63g+dZp9HDEgv/c6IPlPLMJI=
 cloud.google.com/go/storage v1.1.2/go.mod h1:/03MkR5FWjF0OpcKpdJ4RgWybEaYAr2boHXq5RDlxbw=
 cloud.google.com/go/storage v1.4.0 h1:KDdqY5VTXBTqpSbctVTt0mVvfanP6JZzNzLE0qNY100=
 cloud.google.com/go/storage v1.4.0/go.mod h1:ZusYJWlOshgSBGbt6K3GnB3MT3H1xs2id9+TCl4fDBA=
@@ -133,6 +131,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-assets v0.0.0-20160921144138-4f4301a06e15 h1:cW/amwGEJK5MSKntPXRjX4dxs/nGxGT8gXKIsKFmHGc=
 github.com/jessevdk/go-assets v0.0.0-20160921144138-4f4301a06e15/go.mod h1:Fdm/oWRW+CH8PRbLntksCNtmcCBximKPkVQYvmMl80k=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
@@ -174,6 +174,7 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -256,7 +257,6 @@ golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm0
 golang.org/x/exp v0.0.0-20191014171548-69215a2ee97e h1:ewBcnrlKhy0GKnQ31tXkOC/G7/jHC4ogar1TiIfANC4=
 golang.org/x/exp v0.0.0-20191014171548-69215a2ee97e/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20191024150812-c286b889502e/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
-golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136 h1:A1gGSx58LAGVHUUsOf7IiR0u8Xb6W51gRwfDBhkdcaw=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587 h1:5Uz0rkjCFu9BC9gCRN7EkwVvhNyQgGWb8KNJrPwBoHY=
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
@@ -292,7 +292,6 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191207000613-e7e4b65ae663 h1:Dd5RoEW+yQi+9DMybroBctIdyiwuNT7sJFMC27/6KxI=
 golang.org/x/net v0.0.0-20191207000613-e7e4b65ae663/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -327,7 +326,6 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab h1:FvshnhkKW+LO3HWHodML8kuVX8rnJTxKm9dFPuI68UM=
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -368,7 +366,6 @@ golang.org/x/tools v0.0.0-20191105231337-689d0f08e67a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd h1:Zc7EU2PqpsNeIfOoVA7hvQX4cS3YDJEs5KlfatT3hLo=
 golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191213221258-04c2e8eff935 h1:kJQZhwFzSwJS2BxboKjdZzWczQOZx8VuH7Y8hhuGUtM=
 golang.org/x/tools v0.0.0-20191213221258-04c2e8eff935/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
@@ -380,7 +377,6 @@ google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEn
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.11.0 h1:n/qM3q0/rV2F0pox7o0CvNhlPvZAo7pLbef122cbLJ0=
 google.golang.org/api v0.11.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
-google.golang.org/api v0.13.0 h1:Q3Ui3V3/CVinFWFiW39Iw0kMuVrRzYX0wN6OPFp0lTA=
 google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/api v0.14.0 h1:uMf5uLi4eQMRrMKhCplNik4U4H8Z6C1br3zOtAa/aDE=
 google.golang.org/api v0.14.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=

--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -55,4 +55,7 @@ type ArgType struct {
 
 	// FromDDL indicates generating from ddl flie or not.
 	FromDDL bool
+
+	// InflectionRuleFile is custom inflection rule file.
+	InflectionRuleFile string
 }

--- a/internal/inflector.go
+++ b/internal/inflector.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"io/ioutil"
+
+	"github.com/gedex/inflector"
+	"github.com/jinzhu/inflection"
+	"gopkg.in/yaml.v2"
+)
+
+type Inflector interface {
+	Singularize(string) string
+	Pluralize(string) string
+}
+
+type DefaultInflector struct{}
+type RuleInflector struct{}
+
+func (i *DefaultInflector) Singularize(s string) string {
+	return inflector.Singularize(s)
+}
+func (i *DefaultInflector) Pluralize(s string) string {
+	return inflector.Pluralize(s)
+}
+
+func (i *RuleInflector) Singularize(s string) string {
+	return inflection.Singular(s)
+}
+func (i *RuleInflector) Pluralize(s string) string {
+	return inflection.Plural(s)
+}
+
+func NewInflector(ruleFile string) (Inflector, error) {
+	if ruleFile == "" {
+		return &DefaultInflector{}, nil
+	}
+	err := registerRule(ruleFile)
+	if err != nil {
+		return nil, err
+	}
+	return &RuleInflector{}, nil
+}
+
+type InflectRule struct {
+	Singuler string `yaml:"singular"`
+	Plural   string `yaml:"plural"`
+}
+
+func registerRule(inflectionRuleFile string) error {
+	rules, err := readRule(inflectionRuleFile)
+	if err != nil {
+		return err
+	}
+	if rules != nil {
+		for _, irr := range rules {
+			inflection.AddIrregular(irr.Singuler, irr.Plural)
+		}
+	}
+	return nil
+}
+
+func readRule(ruleFile string) ([]InflectRule, error) {
+	data, err := ioutil.ReadFile(ruleFile)
+	if err != nil {
+		return nil, err
+	}
+	var rules []InflectRule
+	err = yaml.Unmarshal(data, &rules)
+	if err != nil {
+		return nil, err
+	}
+	return rules, nil
+
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gedex/inflector"
 	"github.com/knq/snaker"
 )
 
@@ -26,11 +25,11 @@ func reverseIndexRune(s string, r rune) int {
 
 // SinguralizeIdentifier will singularize a identifier, returning it in
 // CamelCase.
-func SingularizeIdentifier(s string) string {
+func SingularizeIdentifier(in Inflector, s string) string {
 	if i := reverseIndexRune(s, '_'); i != -1 {
-		s = s[:i] + "_" + inflector.Singularize(s[i+1:])
+		s = s[:i] + "_" + in.Singularize(s[i+1:])
 	} else {
-		s = inflector.Singularize(s)
+		s = in.Singularize(s)
 	}
 
 	// return snaker.SnakeToCamelIdentifier(s)


### PR DESCRIPTION
Hi!

Our some table, like `lives` generated to `life.yo.go`, and in `type.go.tpl` `.Name` assigned to  `Life`.
But We want  generated code like `live.yo.go`, `Live`.

So, I changed to use https://github.com/jinzhu/inflection for defining custom irregular inflection rule.
If `--inflection-rule-file` option used, words inflected by https://github.com/jinzhu/inflection using rule file.
And for backward compatibility, if `--inflection-rule-file` option does not used, words inflected by github.com/gedex/inflector as usual.

How do you think this PR?
Please review this.

I agree with cla
https://www.mercari.com/cla/

Thank you!