### PR TITLE
update Go version to 1.24 in CircleCI config and Go modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: golang:1.23-bullseye
+      - image: golang:1.24-bullseye
         environment:
           SPANNER_EMULATOR_HOST: localhost:9010
           SPANNER_EMULATOR_HOST_REST: localhost:9020
@@ -55,7 +55,7 @@ jobs:
 
   v2test:
     docker:
-      - image: golang:1.23-bullseye
+      - image: golang:1.24-bullseye
         environment:
           SPANNER_EMULATOR_HOST: localhost:9010
           SPANNER_EMULATOR_HOST_REST: localhost:9020
@@ -100,7 +100,7 @@ jobs:
             make -C v2 check-diff
   check_lint:
     docker:
-      - image: golang:1.23-bullseye
+      - image: golang:1.24-bullseye
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout
@@ -110,7 +110,7 @@ jobs:
             make check_lint
   check_go_mod:
     docker:
-      - image: golang:1.23-bullseye
+      - image: golang:1.24-bullseye
     working_directory: /go/src/github.com/cloudspannerecosystem/yo
     steps:
       - checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Go 1.23
+      - name: Set up Go 1.24
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.mercari.io/yo
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.5
+toolchain go1.24.5
 
 require (
 	cloud.google.com/go v0.118.3

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module go.mercari.io/yo/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go v0.118.3


### PR DESCRIPTION
New PRs are failing because 1.23 is no longer supported by `make dep`