### PR TITLE
update go-assets-builder installation method in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build: regen ## build yo command and regenerate template bin
 regen: tplbin/templates.go ## regenerate template bin
 
 deps:
-	go get -u github.com/jessevdk/go-assets-builder
+	go install github.com/jessevdk/go-assets-builder@latest
 
 .PHONY: gomod
 gomod: ## Run go mod


### PR DESCRIPTION
To avoid go version error in CircleCI like that:

```
go get -u github.com/jessevdk/go-assets-builder
go: downloading github.com/jessevdk/go-assets-builder v0.0.0-20130903091706-b8483521738f
go: downloading github.com/jessevdk/go-assets v0.0.0-20160921144138-4f4301a06e15
go: downloading github.com/jessevdk/go-flags v1.6.1
go: downloading golang.org/x/sys v0.31.0
go: downloading golang.org/x/sys v0.36.0
go: golang.org/x/sys@v0.36.0 requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
make: *** [Makefile:21: deps] Error 1

Exited with code exit status 2
```