### PR TITLE
Deprecate schema-based generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ cd $GOPATH/src/path/to/project
 # make an output directory
 $ mkdir -p models
 
-# generate code for a schema
+# generate code for a schema (deprecated: use --from-ddl instead)
 $ yo $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models
 ```
 
@@ -44,7 +44,8 @@ $ yo --help
 yo is a command-line tool to generate Go code for Google Cloud Spanner.
 
 Usage:
-  yo PROJECT_NAME INSTANCE_NAME DATABASE_NAME [flags]
+  yo generate [DDL_FILE] [flags]
+  yo PROJECT_NAME INSTANCE_NAME DATABASE_NAME [flags] (deprecated: use `yo generate DDL_FILE --from-ddl` instead)
 
 Examples:
   # Generate models from DDL under the models directory
@@ -52,12 +53,6 @@ Examples:
   
   # Generate models from DDL under the models directory with custom types
   yo generate schame.sql --from-ddl -o models --custom-types-file custom_column_types.yml
-  
-  # Generate models under models directory
-  yo $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models
-
-  # Generate models under models directory with custom types
-  yo $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models --custom-types-file custom_column_types.yml
 
 Flags:
       --custom-type-package string   Go package name to use for custom or unknown types

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ var version string
 var (
 	rootOpts = internal.ArgType{}
 	rootCmd  = &cobra.Command{
-		Use:   "yo PROJECT_NAME INSTANCE_NAME DATABASE_NAME",
+		Use:   "yo PROJECT_NAME INSTANCE_NAME DATABASE_NAME (deprecated: use `yo generate <DDL_FILE> --from-ddl` instead)",
 		Short: "yo is a command-line tool to generate Go code for Google Cloud Spanner.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
@@ -60,6 +60,9 @@ var (
 		},
 		Example: strings.Trim(exampleUsage, "\n"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 3 {
+				fmt.Println("Warning: Generating models directly from Spanner project, instance, and database names is deprecated. Please use `yo generate <DDL_FILE> --from-ddl` instead.")
+			}
 			if err := processArgs(&rootOpts, args); err != nil {
 				return err
 			}

--- a/v2/README.md
+++ b/v2/README.md
@@ -25,7 +25,7 @@ $ cd $GOPATH/src/path/to/project
 # make an output directory
 $ mkdir -p models
 
-# generate code for a schema
+# generate code for a schema (deprecated: use --from-ddl instead)
 $ yo generate $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models
 ```
 
@@ -43,12 +43,6 @@ yo generate schema.sql --from-ddl -o models
 
 # Generate models from DDL under the models directory with custom types
 yo generate schema.sql --from-ddl -o models --custom-types-file custom_column_types.yml
-
-# Generate models under the models directory
-yo generate $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models
-
-# Generate models under the models directory with custom types
-yo generate $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models --custom-types-file custom_column_types.yml
 ```
 
 #### Flags

--- a/v2/cmd/generate.go
+++ b/v2/cmd/generate.go
@@ -117,14 +117,12 @@ var (
 
   # Generate models from DDL under the models directory with custom types
   yo generate schema.sql --from-ddl -o models --custom-types-file custom_column_types.yml
-
-  # Generate models under the models directory
-  yo generate $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models
-
-  # Generate models under the models directory with custom types
-  yo generate $SPANNER_PROJECT_NAME $SPANNER_INSTANCE_NAME $SPANNER_DATABASE_NAME -o models --custom-types-file custom_column_types.yml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 3 {
+				fmt.Println("Warning: Generating models directly from Spanner project, instance, and database names is deprecated. Please use `yo generate <DDL_FILE> --from-ddl` instead.")
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 


### PR DESCRIPTION
This feature is being deprecated due to discrepancies between generation from the Spanner Emulator and actual Spanner Instances.

https://github.com/cloudspannerecosystem/yo/issues/154
