### PR TITLE
Apply PR #110's Read index doc comment fix to the v2 legacy index module

### DIFF
--- a/v2/module/builtin/templates/legacy_index.go.tpl
+++ b/v2/module/builtin/templates/legacy_index.go.tpl
@@ -103,7 +103,7 @@ func Find{{ .LegacyFuncName }}(ctx context.Context, db YODB{{ goParams .Fields t
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index '{{ .IndexName }}'.
+// Generated from index '{{ .IndexName }}'.
 func Read{{ .LegacyFuncName }}(ctx context.Context, db YODB, keys spanner.KeySet) ([]*{{ .Type.Name }}, error) {
 	var res []*{{ .Type.Name }}
     columns := []string{

--- a/v2/test/testmodels/legacy_default/composite_primary_key.yo.go
+++ b/v2/test/testmodels/legacy_default/composite_primary_key.yo.go
@@ -259,7 +259,7 @@ func FindCompositePrimaryKeysByError(ctx context.Context, db YODB, e int64) ([]*
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByError'.
+// Generated from index 'CompositePrimaryKeysByError'.
 func ReadCompositePrimaryKeysByError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{
@@ -334,7 +334,7 @@ func FindCompositePrimaryKeysByZError(ctx context.Context, db YODB, e int64) ([]
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByError2'.
+// Generated from index 'CompositePrimaryKeysByError2'.
 func ReadCompositePrimaryKeysByZError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{
@@ -410,7 +410,7 @@ func FindCompositePrimaryKeysByZYError(ctx context.Context, db YODB, e int64) ([
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByError3'.
+// Generated from index 'CompositePrimaryKeysByError3'.
 func ReadCompositePrimaryKeysByZYError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{
@@ -488,7 +488,7 @@ func FindCompositePrimaryKeysByXY(ctx context.Context, db YODB, x string, y stri
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CompositePrimaryKeysByXY'.
+// Generated from index 'CompositePrimaryKeysByXY'.
 func ReadCompositePrimaryKeysByXY(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CompositePrimaryKey, error) {
 	var res []*CompositePrimaryKey
 	columns := []string{

--- a/v2/test/testmodels/legacy_default/custom_composite_primary_key.yo.go
+++ b/v2/test/testmodels/legacy_default/custom_composite_primary_key.yo.go
@@ -259,7 +259,7 @@ func FindCustomCompositePrimaryKeysByError(ctx context.Context, db YODB, e int8)
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByError'.
+// Generated from index 'CustomCompositePrimaryKeysByError'.
 func ReadCustomCompositePrimaryKeysByError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{
@@ -334,7 +334,7 @@ func FindCustomCompositePrimaryKeysByZError(ctx context.Context, db YODB, e int8
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByError2'.
+// Generated from index 'CustomCompositePrimaryKeysByError2'.
 func ReadCustomCompositePrimaryKeysByZError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{
@@ -410,7 +410,7 @@ func FindCustomCompositePrimaryKeysByZYError(ctx context.Context, db YODB, e int
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByError3'.
+// Generated from index 'CustomCompositePrimaryKeysByError3'.
 func ReadCustomCompositePrimaryKeysByZYError(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{
@@ -488,7 +488,7 @@ func FindCustomCompositePrimaryKeysByXY(ctx context.Context, db YODB, x string, 
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'CustomCompositePrimaryKeysByXY'.
+// Generated from index 'CustomCompositePrimaryKeysByXY'.
 func ReadCustomCompositePrimaryKeysByXY(ctx context.Context, db YODB, keys spanner.KeySet) ([]*CustomCompositePrimaryKey, error) {
 	var res []*CustomCompositePrimaryKey
 	columns := []string{

--- a/v2/test/testmodels/legacy_default/full_type.yo.go
+++ b/v2/test/testmodels/legacy_default/full_type.yo.go
@@ -440,7 +440,7 @@ func FindFullTypeByFTString(ctx context.Context, db YODB, fTString string) (*Ful
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByFTString'.
+// Generated from index 'FullTypesByFTString'.
 func ReadFullTypeByFTString(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -523,7 +523,7 @@ func FindFullTypesByFTIntFTTimestampNull(ctx context.Context, db YODB, fTInt int
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByInTimestampNull'.
+// Generated from index 'FullTypesByInTimestampNull'.
 func ReadFullTypesByFTIntFTTimestampNull(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -599,7 +599,7 @@ func FindFullTypesByFTIntFTDate(ctx context.Context, db YODB, fTInt int64, fTDat
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByIntDate'.
+// Generated from index 'FullTypesByIntDate'.
 func ReadFullTypesByFTIntFTDate(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -675,7 +675,7 @@ func FindFullTypesByFTIntFTTimestamp(ctx context.Context, db YODB, fTInt int64, 
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByIntTimestamp'.
+// Generated from index 'FullTypesByIntTimestamp'.
 func ReadFullTypesByFTIntFTTimestamp(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{
@@ -750,7 +750,7 @@ func FindFullTypesByFTTimestamp(ctx context.Context, db YODB, fTTimestamp time.T
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'FullTypesByTimestamp'.
+// Generated from index 'FullTypesByTimestamp'.
 func ReadFullTypesByFTTimestamp(ctx context.Context, db YODB, keys spanner.KeySet) ([]*FullType, error) {
 	var res []*FullType
 	columns := []string{

--- a/v2/test/testmodels/legacy_default/snake_case.yo.go
+++ b/v2/test/testmodels/legacy_default/snake_case.yo.go
@@ -231,7 +231,7 @@ func FindSnakeCasesByStringIDFooBarBaz(ctx context.Context, db YODB, stringID st
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'snake_cases_by_string_id'.
+// Generated from index 'snake_cases_by_string_id'.
 func ReadSnakeCasesByStringIDFooBarBaz(ctx context.Context, db YODB, keys spanner.KeySet) ([]*SnakeCase, error) {
 	var res []*SnakeCase
 	columns := []string{

--- a/v2/test/testmodels/legacy_default/uuid_type.yo.go
+++ b/v2/test/testmodels/legacy_default/uuid_type.yo.go
@@ -237,7 +237,7 @@ func FindUUIDTypeByName(ctx context.Context, db YODB, name string) (*UUIDType, e
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'UuidTypesByName'.
+// Generated from index 'UuidTypesByName'.
 func ReadUUIDTypeByName(ctx context.Context, db YODB, keys spanner.KeySet) ([]*UUIDType, error) {
 	var res []*UUIDType
 	columns := []string{
@@ -318,7 +318,7 @@ func FindUUIDTypesByOptionalID(ctx context.Context, db YODB, optionalID spanner.
 // used for primary key, index key and storing columns. If you need more columns, add storing
 // columns or Read by primary key or Query with join.
 //
-// Generated from unique index 'UuidTypesByOptionalID'.
+// Generated from index 'UuidTypesByOptionalID'.
 func ReadUUIDTypesByOptionalID(ctx context.Context, db YODB, keys spanner.KeySet) ([]*UUIDType, error) {
 	var res []*UUIDType
 	columns := []string{


### PR DESCRIPTION
## Summary

`v2/module/builtin/templates/legacy_index.go.tpl` hardcodes the doc comment on every generated `Read{{ .LegacyFuncName }}` as `// Generated from unique index '...'.`, even when the underlying index is **not** unique. Users of the legacy index module (`--use-legacy-index-module`) therefore still see misleading doc comments on non-unique-index `ReadXxx` functions.

This is the same issue that #110 (merged 2022-12-07) fixed for `module/builtin/templates/index.go.tpl`, and that #205 backported to the v1 templates. `legacy_index.go.tpl` was missed by both, so after #205 the v1 output and the v2 legacy output disagree on the same comment:

```go
// v1 (after #205)                      // v2 legacy (today)
// Generated from index '...'.          // Generated from unique index '...'.
func ReadCompositePrimaryKeysByError(   func ReadCompositePrimaryKeysByError(
```

## Change

Mirror #110 and #205 exactly — drop the word `unique` from the `Read{{ .LegacyFuncName }}` doc comment so it reads `// Generated from index '...'.` regardless of uniqueness:

```diff                                                                                                                  -// Generated from unique index '{{ .IndexName }
+// Generated from index '{{ .IndexName }}'.                                                                              func Read{{ .LegacyFuncName }}(ctx context.Cont.KeySet) ([]*{{ .Type.Name }}, error) {
```                                                                                                                      
`v2/test/testmodels/legacy_default/**/*.yo.go` is regenerated via `make -C v2 testdata-from-ddl` to reflect the template change.

The `Find{{ .LegacyFuncName }}` comment is left nside an `{{ if .IsUnique }}` branch, so `uniqueindex` is accurate there.

## Scope

- Comment-only change. No runtime behavior change.
- Touches only `v2/module/builtin/templates/legaegenerated `v2/test/testmodels/legacy_default/`(5 files, 17 lines).
- `v2/test/testmodels/default/` and `dump_types/legacy index module was already fixed by #110.
- v2 embeds templates with `go:embed` (`v2/module/builtin/module.go`), so there is no v1-style `tplbin` regeneration step.
- The v1 tree is untouched (already fixed by #20